### PR TITLE
fix meta tx context trait

### DIFF
--- a/contracts/registry/lib.rs
+++ b/contracts/registry/lib.rs
@@ -179,8 +179,8 @@ mod registry {
             let mut registry = Registry::new([0x0; 32].into());
             assert_eq!(registry.set_trusted_forwarder([0x1; 32].into()), Ok(()));
             assert_eq!(
-                registry.get_trusted_forwarder(),
-                Some(AccountId::from([0x1; 32]))
+                registry.is_trusted_forwarder(AccountId::from([0x1; 32])),
+                true
             );
         }
 

--- a/crates/meta_tx_context/src/lib.rs
+++ b/crates/meta_tx_context/src/lib.rs
@@ -29,8 +29,8 @@ impl<T> MetaTxContext for T
 where
     T: Storage<Data> + Storage<access_control::Data>,
 {
-    default fn get_trusted_forwarder(&self) -> Option<AccountId> {
-        self.data::<Data>().trusted_forwarder
+    default fn is_trusted_forwarder(&self, account_id: AccountId) -> bool {
+        self.data::<Data>().trusted_forwarder == Some(account_id)
     }
 
     #[modifiers(only_role(DEFAULT_ADMIN_ROLE))]

--- a/crates/meta_tx_context/src/traits.rs
+++ b/crates/meta_tx_context/src/traits.rs
@@ -11,7 +11,7 @@ pub type MetaTxContextRef = dyn MetaTxContext;
 #[openbrush::trait_definition]
 pub trait MetaTxContext {
     #[ink(message)]
-    fn get_trusted_forwarder(&self) -> Option<AccountId>;
+    fn is_trusted_forwarder(&self, account_id: AccountId) -> bool;
 
     #[ink(message)]
     fn set_trusted_forwarder(&mut self, forwarder: AccountId) -> Result<(), AccessControlError>;


### PR DESCRIPTION
Same as ERC2771 Protocol support discovery mechanism
https://eips.ethereum.org/EIPS/eip-2771#protocol-support-discovery-mechanism

`get_trusted_forwarder` -> `is_trusted_forwarder`